### PR TITLE
fix: raise vitest hookTimeout to survive mongodb-memory-server binary download on fresh clone

### DIFF
--- a/packages/eventstore/vite.config.ts
+++ b/packages/eventstore/vite.config.ts
@@ -28,5 +28,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    hookTimeout: 120000,
   },
 })


### PR DESCRIPTION
On a fresh clone, `mongodb-memory-server` downloads a ~65 MB MongoDB binary before the first test run. This takes longer than vitest's default 10 s `hookTimeout`, causing `beforeAll` to time out, `eventStore` to stay `undefined`, and `afterAll` to throw a `TypeError`. Raising the timeout to 120 s ensures tests pass reliably on first run (subsequent runs use the cached binary and are unaffected)