### PR TITLE
fix(projections): evolve kann Löschung ueber null-Rückgabe signalisieren

### DIFF
--- a/packages/eventstore/eventStore/eventStoreFactory.test.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.test.ts
@@ -119,8 +119,8 @@ describe('mongoClientWrapper Integration Tests', () => {
       const projectionDefinition = createProjectionDefinition({
         name: 'TestProjection',
         canHandle: ['user.created'],
-        evolve: (state: { count: number }) => {
-          return { count: state.count + 1 }
+        evolve: (state: { count: number } | null) => {
+          return { count: (state?.count ?? 0) + 1 }
         },
         initialState: () => ({ count: 0 }),
       })
@@ -136,8 +136,8 @@ describe('mongoClientWrapper Integration Tests', () => {
       const projectionDefinition = createProjectionDefinition({
         name: 'TestProjection',
         canHandle: ['user.created'],
-        evolve: (state: { count: number }) => {
-          return { count: state.count + 1 }
+        evolve: (state: { count: number } | null) => {
+          return { count: (state?.count ?? 0) + 1 }
         },
         initialState: () => ({ count: 0 }),
       })
@@ -208,8 +208,8 @@ describe('mongoClientWrapper Integration Tests', () => {
       const projectionDefinition = createProjectionDefinition({
         name: 'EventCountProjection',
         canHandle: ['user.created'],
-        evolve: (state: { count: number }) => {
-          return { count: state.count + 1 }
+        evolve: (state: { count: number } | null) => {
+          return { count: (state?.count ?? 0) + 1 }
         },
         initialState: () => ({ count: 0 }),
       })

--- a/packages/eventstore/eventStore/eventStoreFactory.test.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.test.ts
@@ -244,6 +244,110 @@ describe('mongoClientWrapper Integration Tests', () => {
       expect(stream1?.projections?.EventCountProjection).toEqual({ count: 1 })
       expect(stream2?.projections?.EventCountProjection).toEqual({ count: 1 })
     })
+
+    describe('projection deletion via null evolve return', () => {
+      const deletionProjection = createProjectionDefinition({
+        name: 'DeletionProjection',
+        canHandle: ['user.created', 'user.deleted'],
+        evolve: (state: { count: number } | null, event: { type: string }) => {
+          if (event.type === 'user.deleted')
+            return null
+          return { count: (state?.count ?? 0) + 1 }
+        },
+        initialState: () => null,
+      })
+
+      it('should $unset the projection field when evolve returns null', async () => {
+        const testEventStore = createEventStore({ connectionString, projections: [deletionProjection] })
+        await testEventStore.getInstanceMongoClientWrapper().waitForConnection()
+
+        const subject = createSubject('user/999/created')
+        const streamSubject = getStreamSubjectFromSubject(subject)
+
+        const created = createDomainEvent({
+          type: 'user.created',
+          subject,
+          data: { name: 'Erin Example', email: 'erin@example.com' },
+        })
+
+        const createdResult = await testEventStore.appendOrCreateStream([created])
+        expect(createdResult.streams[0]?.projections?.DeletionProjection).toEqual({ count: 1 })
+
+        const deleted = createDomainEvent({
+          type: 'user.deleted',
+          subject,
+        })
+
+        const deletedResult = await testEventStore.appendOrCreateStream([deleted])
+        expect(deletedResult.streams[0]?.projections?.DeletionProjection).toBeUndefined()
+
+        // The field must be removed from the stored document (via $unset), not merely set to null
+        const rawDocument = await testEventStore.getCollectionBySubject(streamSubject).findOne({ streamSubject })
+        expect(rawDocument?.projections).not.toHaveProperty('DeletionProjection')
+      })
+
+      it('should re-evolve from initial state after the projection was previously deleted', async () => {
+        const testEventStore = createEventStore({ connectionString, projections: [deletionProjection] })
+        await testEventStore.getInstanceMongoClientWrapper().waitForConnection()
+
+        const subject = createSubject('user/998/created')
+
+        const created = createDomainEvent({ type: 'user.created', subject })
+        const deleted = createDomainEvent({ type: 'user.deleted', subject })
+        const recreated = createDomainEvent({ type: 'user.created', subject })
+
+        await testEventStore.appendOrCreateStream([created])
+        await testEventStore.appendOrCreateStream([deleted])
+        const result = await testEventStore.appendOrCreateStream([recreated])
+
+        // Started fresh from initialState() (null) rather than continuing the previous count
+        expect(result.streams[0]?.projections?.DeletionProjection).toEqual({ count: 1 })
+      })
+
+      it('should delete the projection when both events land in the same append call', async () => {
+        const testEventStore = createEventStore({ connectionString, projections: [deletionProjection] })
+        await testEventStore.getInstanceMongoClientWrapper().waitForConnection()
+
+        const subject = createSubject('user/997/created')
+
+        const created = createDomainEvent({ type: 'user.created', subject })
+        const deleted = createDomainEvent({ type: 'user.deleted', subject })
+
+        const result = await testEventStore.appendOrCreateStream([created, deleted])
+
+        expect(result.streams[0]?.projections?.DeletionProjection).toBeUndefined()
+      })
+
+      it('should combine $set and $unset in a single append call when one projection is updated and a sibling projection is deleted', async () => {
+        const keepProjection = createProjectionDefinition({
+          name: 'KeepProjection',
+          canHandle: ['user.created', 'user.deleted'],
+          evolve: (state: { count: number } | null) => ({ count: (state?.count ?? 0) + 1 }),
+          initialState: () => null,
+        })
+
+        const testEventStore = createEventStore({
+          connectionString,
+          projections: [deletionProjection, keepProjection],
+        })
+        await testEventStore.getInstanceMongoClientWrapper().waitForConnection()
+
+        const subject = createSubject('user/996/created')
+
+        // Seed both projections with a non-null state so the second call below
+        // exercises an update ($set), not just an initial creation.
+        const created = createDomainEvent({ type: 'user.created', subject })
+        await testEventStore.appendOrCreateStream([created])
+
+        // This single append call is what's under test: DeletionProjection evolves
+        // to null ($unset) while KeepProjection evolves to a new state ($set).
+        const deleted = createDomainEvent({ type: 'user.deleted', subject })
+        const result = await testEventStore.appendOrCreateStream([deleted])
+
+        expect(result.streams[0]?.projections?.DeletionProjection).toBeUndefined()
+        expect(result.streams[0]?.projections?.KeepProjection).toEqual({ count: 2 })
+      })
+    })
   })
 
   describe('aggregateStream', () => {

--- a/packages/eventstore/eventStore/eventStoreFactory.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.ts
@@ -84,12 +84,28 @@ async function processStreamInTransaction<
     )
 
     const setUpdates: Record<string, any> = {}
+    const unsetUpdates: Record<string, any> = {}
     for (const projection of applicableProjections) {
-      const state = events.reduce((state, event) => projection.evolve(state, event), result?.projections?.[projection.name] || projection.initialState())
-      setUpdates[`projections.${projection.name}`] = state
+      const state = events.reduce(
+        (state, event) => projection.evolve(state, event),
+        result?.projections?.[projection.name] ?? projection.initialState(),
+      )
+
+      if (state === null) {
+        unsetUpdates[`projections.${projection.name}`] = ''
+      }
+      else {
+        setUpdates[`projections.${projection.name}`] = state
+      }
     }
 
-    const projectionUpdates: UpdateFilter<EventStream<TDomainEvent, TProjections>> = { $set: setUpdates }
+    const projectionUpdates: UpdateFilter<EventStream<TDomainEvent, TProjections>> = {}
+    if (Object.keys(setUpdates).length > 0) {
+      projectionUpdates.$set = setUpdates
+    }
+    if (Object.keys(unsetUpdates).length > 0) {
+      projectionUpdates.$unset = unsetUpdates
+    }
     result = await collection.findOneAndUpdate(
       { streamSubject },
       projectionUpdates,

--- a/packages/eventstore/utils/utilsProjections.test.ts
+++ b/packages/eventstore/utils/utilsProjections.test.ts
@@ -155,6 +155,94 @@ describe('findSingleProjection', () => {
   })
 })
 
+describe('projection deletion via null evolve return', () => {
+  let replSet: MongoMemoryReplSet
+  let eventStore: EventStoreInstance<typeof projectionDefinition[]>
+  let connectionString: string
+
+  type SaltAddedEvent = DomainEvent<'recepie.salt.added', { amount: number }, undefined>
+  type SaltRemovedEvent = DomainEvent<'recepie.salt.removed', undefined, undefined>
+  type TestEvents = SaltAddedEvent | SaltRemovedEvent
+
+  const projectionDefinition = createProjectionDefinition({
+    name: 'testProjection',
+    evolve: (state: { saltAdded: number } | null, event: TestEvents) => {
+      if (event.type === 'recepie.salt.removed')
+        return null
+      if (!state)
+        return { saltAdded: event.data.amount }
+      return { ...state, saltAdded: state.saltAdded + event.data.amount }
+    },
+    canHandle: ['recepie.salt.added', 'recepie.salt.removed'],
+    initialState: () => null,
+  })
+
+  beforeAll(async () => {
+    // Start in-memory MongoDB replica set for transaction support
+    replSet = await MongoMemoryReplSet.create({
+      replSet: { count: 3 }, // Create a replica set with 3 members
+    })
+    connectionString = replSet.getUri()
+    eventStore = createEventStore({ connectionString, projections: [projectionDefinition] })
+    await eventStore.getInstanceMongoClientWrapper().waitForConnection()
+  })
+
+  afterEach(async () => {
+    // Clean up collections between tests
+    const db = eventStore.getInstanceMongoClientWrapper().getDatabase()
+    const collections = await db.collections()
+    for (const collection of collections) {
+      await collection.drop()
+    }
+  })
+
+  afterAll(async () => {
+    await eventStore.getInstanceMongoClientWrapper().close()
+    await replSet.stop()
+  })
+
+  it('should no longer find a deleted projection with findOneProjection', async () => {
+    const testSubject = createSubject('recepie/555')
+    const streamSubject = getStreamSubjectFromSubject(testSubject)
+
+    await eventStore.appendOrCreateStream([
+      createDomainEvent({ type: 'recepie.salt.added', subject: testSubject, data: { amount: 1 } }),
+    ])
+    await eventStore.appendOrCreateStream([
+      createDomainEvent({ type: 'recepie.salt.removed', subject: testSubject }),
+    ])
+
+    const projection = await findOneProjection(eventStore, streamSubject, {
+      projectionName: 'testProjection',
+    })
+
+    expect(projection).toBeNull()
+  })
+
+  it('should exclude a deleted projection from findMultipleProjections and countProjections', async () => {
+    const keptSubject = createSubject('recepie/601')
+    const deletedSubject = createSubject('recepie/602')
+
+    await eventStore.appendOrCreateStream([
+      createDomainEvent({ type: 'recepie.salt.added', subject: keptSubject, data: { amount: 1 } }),
+    ])
+    await eventStore.appendOrCreateStream([
+      createDomainEvent({ type: 'recepie.salt.added', subject: deletedSubject, data: { amount: 1 } }),
+    ])
+    await eventStore.appendOrCreateStream([
+      createDomainEvent({ type: 'recepie.salt.removed', subject: deletedSubject }),
+    ])
+
+    const streamFilter = { projectionName: 'testProjection' } as const
+
+    const projections = await findMultipleProjections(eventStore, 'recepie', streamFilter, { skip: 0, limit: 50 })
+    expect(projections.length).toBe(1)
+
+    const count = await countProjections(eventStore, 'recepie', streamFilter)
+    expect(count).toBe(1)
+  })
+})
+
 describe('findMultipleProjections', () => {
   let replSet: MongoMemoryReplSet
   let eventStore: EventStoreInstance<typeof projectionDefinitions>

--- a/packages/eventstore/utils/utilsProjections.ts
+++ b/packages/eventstore/utils/utilsProjections.ts
@@ -22,7 +22,7 @@ export function createProjectionDefinition<
 >(config: {
   name: TName
   canHandle: CanHandle<TEvent>
-  evolve: (state: TState, event: TEvent) => TState
+  evolve: (state: TState | null, event: TEvent) => TState | null
   initialState: () => TState | null
 }): ProjectionDefinition<TState, TName, TEvent> {
   return {

--- a/packages/eventstore/utils/utilsProjections.types.ts
+++ b/packages/eventstore/utils/utilsProjections.types.ts
@@ -12,7 +12,14 @@ export interface ProjectionDefinition<
 > {
   name: TName
   canHandle: CanHandle<TEventType>
-  evolve: (state: TState, event: TEventType) => TState
+  /**
+   * `state` is null when the projection doesn't exist yet (before the first
+   * applicable event) or was deleted by a previous evolve call in the same
+   * batch. Returning `null` deletes the projection document: the event store
+   * removes `projections.<name>` from the stream instead of persisting a
+   * null value.
+   */
+  evolve: (state: TState | null, event: TEventType) => TState | null
   initialState: () => TState | null
 }
 


### PR DESCRIPTION
Bisher verlangte ProjectionDefinition.evolve zwingend einen nicht-nullable Rückgabewert, obwohl initialState() bereits null liefern durfte. Damit gab es keinen sauberen Weg, ein Projection-Dokument wieder zu entfernen (z.B. bei einem Lösch-Event) - Domains mussten stattdessen einen Status-Flag im sonst unveraenderten State mitschleifen.

evolve akzeptiert und liefert jetzt TState | null (Pattern aus Emmett/ pongo: https://event-driven-io.github.io/emmett/guides/projections.html#delete-document). Der Event Store setzt projections.<name> per $unset zuruük statt es auf null zu $set-en, sodass bestehende {$exists: true}-Filter (findOneProjection, findMultipleProjections, countProjections) das Dokument automatisch nicht mehr finden.

Beispiel, das vorher zu einem Typfehler zwang:

  // vorher: state muss TState bleiben, "geloescht" braucht einen Flag
  case 'Kategorie.Geloescht':
    return { ...state, geloescht: true }  // Dokument existiert weiter, muss ueberall gefiltert werden

  // jetzt: das Dokument verschwindet tatsaechlich aus der Projection
  case 'Kategorie.Geloescht':
    return null