### PR TITLE
release: vorfall 0.3.0

### DIFF
--- a/.changeset/configurable-database-name.md
+++ b/.changeset/configurable-database-name.md
@@ -1,5 +1,0 @@
----
-"vorfall": minor
----
-
-`createEventStore` now accepts all `MongoClientWrapperOptions` (`databaseName`, `options`, `maxRetries`, `retryDelayMs`) in addition to `connectionString`. Previously only the connection string was forwarded, so all data always landed in the database named `default`. `MongoClientWrapperOptions` is now exported from the package root.

--- a/.changeset/esm-only-build.md
+++ b/.changeset/esm-only-build.md
@@ -1,5 +1,0 @@
----
-"vorfall": minor
----
-
-Ship ESM only. The `require` condition in `exports` pointed at the ESM build and was broken for CommonJS consumers; instead of fixing it, the CJS build is dropped entirely. The package now publishes a single ES module entry (`dist/index.js`).

--- a/.changeset/fix-cloudevent-time-attribute.md
+++ b/.changeset/fix-cloudevent-time-attribute.md
@@ -1,5 +1,0 @@
----
-"vorfall": patch
----
-
-`createDomainEvent` now sets the spec-compliant CloudEvents `time` attribute instead of a non-standard `date` extension attribute, and no longer emits the non-standard `version` attribute. Events created before this change carry `date`/`version` as extension attributes; newly created events carry `time`.

--- a/.changeset/fix-unhandled-connect-rejection.md
+++ b/.changeset/fix-unhandled-connect-rejection.md
@@ -1,5 +1,0 @@
----
-"vorfall": patch
----
-
-Fix a crash on startup when MongoDB is unreachable: the fire-and-forget connect in the `MongoClientWrapper` constructor produced an unhandled promise rejection once all retries were exhausted, which terminates the process on Node >= 15. The rejection is now consumed; connection errors still surface via `waitForConnection()` or the first database operation.

--- a/.changeset/projection-canhandle-filter.md
+++ b/.changeset/projection-canhandle-filter.md
@@ -1,5 +1,0 @@
----
-"vorfall": patch
----
-
-Projections no longer receive events outside their `canHandle` list. Previously, when a batch contained at least one applicable event, `evolve` was called with every event in the batch — including types the projection never declared — forcing every evolve implementation to defensively ignore unknown types. Events are now filtered per projection before folding.

--- a/.changeset/readme-matches-api.md
+++ b/.changeset/readme-matches-api.md
@@ -1,5 +1,0 @@
----
-"vorfall": patch
----
-
-Rewrite the README to match the actual API: `createEventStore` is synchronous and takes `connectionString`/`databaseName` (not `mongoUrl`), `canHandle` is a list of event types (not a type-guard function), events are created via `createDomainEvent`/`createSubject`, and appends go through `appendOrCreateStream`. Documents the replica-set requirement for transactions and the ESM-only build, and removes placeholder documentation links.

--- a/.changeset/unique-stream-subject-index.md
+++ b/.changeset/unique-stream-subject-index.md
@@ -1,5 +1,0 @@
----
-"vorfall": patch
----
-
-`appendOrCreateStream` now ensures a unique index on `streamSubject` (once per collection, before the transaction starts). Without it, concurrent upserts for the same new stream could insert duplicate stream documents, and every stream lookup was a collection scan. Note for existing databases: if a collection already contains duplicate `streamSubject` documents, index creation — and therefore the append — will fail until the duplicates are resolved.

--- a/packages/eventstore/CHANGELOG.md
+++ b/packages/eventstore/CHANGELOG.md
@@ -1,5 +1,20 @@
 # vorfall
 
+## 0.3.0
+
+### Minor Changes
+
+- 9a095e0: `createEventStore` now accepts all `MongoClientWrapperOptions` (`databaseName`, `options`, `maxRetries`, `retryDelayMs`) in addition to `connectionString`. Previously only the connection string was forwarded, so all data always landed in the database named `default`. `MongoClientWrapperOptions` is now exported from the package root.
+- 9a095e0: Ship ESM only. The `require` condition in `exports` pointed at the ESM build and was broken for CommonJS consumers; instead of fixing it, the CJS build is dropped entirely. The package now publishes a single ES module entry (`dist/index.js`).
+
+### Patch Changes
+
+- 9a095e0: `createDomainEvent` now sets the spec-compliant CloudEvents `time` attribute instead of a non-standard `date` extension attribute, and no longer emits the non-standard `version` attribute. Events created before this change carry `date`/`version` as extension attributes; newly created events carry `time`.
+- 9a095e0: Fix a crash on startup when MongoDB is unreachable: the fire-and-forget connect in the `MongoClientWrapper` constructor produced an unhandled promise rejection once all retries were exhausted, which terminates the process on Node >= 15. The rejection is now consumed; connection errors still surface via `waitForConnection()` or the first database operation.
+- 9a095e0: Projections no longer receive events outside their `canHandle` list. Previously, when a batch contained at least one applicable event, `evolve` was called with every event in the batch — including types the projection never declared — forcing every evolve implementation to defensively ignore unknown types. Events are now filtered per projection before folding.
+- 9a095e0: Rewrite the README to match the actual API: `createEventStore` is synchronous and takes `connectionString`/`databaseName` (not `mongoUrl`), `canHandle` is a list of event types (not a type-guard function), events are created via `createDomainEvent`/`createSubject`, and appends go through `appendOrCreateStream`. Documents the replica-set requirement for transactions and the ESM-only build, and removes placeholder documentation links.
+- 9a095e0: `appendOrCreateStream` now ensures a unique index on `streamSubject` (once per collection, before the transaction starts). Without it, concurrent upserts for the same new stream could insert duplicate stream documents, and every stream lookup was a collection scan. Note for existing databases: if a collection already contains duplicate `streamSubject` documents, index creation — and therefore the append — will fail until the duplicates are resolved.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/eventstore/package.json
+++ b/packages/eventstore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vorfall",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Event store package for Vorfall monorepo.",
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Version 0.3.0 via `pnpm release` (changesets): see `packages/eventstore/CHANGELOG.md` for the full notes.

- **Minor**: ESM-only build; `createEventStore` forwards all `MongoClientWrapperOptions` (`databaseName`, driver options, retries)
- **Patch**: unhandled-rejection fix in `MongoClientWrapper`, CloudEvents `time` attribute, projection `canHandle` filter, unique index on `streamSubject`, README rewrite

After merge: create the GitHub release `v0.3.0`, which triggers the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)