### PR TITLE
feat: optimistic concurrency control

### DIFF
--- a/.changeset/optimistic-concurrency-control.md
+++ b/.changeset/optimistic-concurrency-control.md
@@ -1,0 +1,11 @@
+---
+"vorfall": minor
+---
+
+Optimistic concurrency control. Stream documents now carry a `version` field (number of events); appends can pass `expectedVersions` per stream subject (`number`, `'no-stream'` or `'any'`) and fail with the new exported `ConcurrencyError` when the stream changed since it was read — rolling back the whole append across all streams in the call. `handleCommand` enforces the versions observed while aggregating automatically, closing the read-decide-append race.
+
+Breaking changes:
+
+- `aggregateStream` now returns `{ state, version, streamExists }` instead of the bare state.
+- `ReadStreamResult` gains a required `version` field.
+- `EventStream` gains a required `version` field. Existing documents are backfilled (`version := events.length`) once per collection before the first append.

--- a/README.md
+++ b/README.md
@@ -109,15 +109,43 @@ async function getUserProfile(userId: string) {
 
 // Or rebuild state directly from the events
 async function getUserState(userId: string) {
-  return eventStore.aggregateStream<UserProfile | null, UserEvent>(
+  const { state, version, streamExists } = await eventStore.aggregateStream<UserProfile | null, UserEvent>(
     createSubject(`user/${userId}`),
     {
       initialState: () => null,
       evolve: (state, event) => userProfileProjection.evolve(state, event),
     },
   )
+  return state
 }
 ```
+
+## Optimistic Concurrency Control
+
+Every stream document carries a `version` (the number of events in the stream). `aggregateStream` and `getEventStreamBySubject` return the version seen at read time; pass it back on append to make the write fail if the stream changed in between:
+
+```typescript
+import { ConcurrencyError } from 'vorfall'
+
+const { state, version } = await eventStore.aggregateStream(streamSubject, { evolve, initialState })
+
+try {
+  await eventStore.appendOrCreateStream([event], {
+    expectedVersions: new Map([[streamSubject, version]]),
+  })
+}
+catch (error) {
+  if (error instanceof ConcurrencyError) {
+    // Someone else appended first: error.expectedVersion vs. error.actualVersion.
+    // Re-read, re-decide, retry — or surface e.g. HTTP 409.
+  }
+  throw error
+}
+```
+
+Expected versions per stream subject can be a number (exact event count, `0` means the stream must not exist yet), `'no-stream'` (append must create the stream) or `'any'` (no check — the default for streams not listed). On a mismatch the whole append is rolled back, including all other streams in the same call.
+
+`handleCommand` wires this automatically: the versions observed while aggregating the configured streams are enforced on append, so a concurrent command on the same stream fails with a `ConcurrencyError` instead of silently interleaving.
 
 ## Installation
 

--- a/packages/eventstore/commandHandling/handleCommand.test.ts
+++ b/packages/eventstore/commandHandling/handleCommand.test.ts
@@ -37,7 +37,7 @@ describe('handleCommand', () => {
       streamSubjects: [streamSubject],
     }
 
-    mockEventStore.aggregateStream.mockResolvedValue(mockedAggregatedState)
+    mockEventStore.aggregateStream.mockResolvedValue({ state: mockedAggregatedState, streamExists: true, version: 3 })
     mockEventStore.appendOrCreateStream.mockResolvedValue(mockedNewState)
 
     type IncrementCounterCommand = Command<'IncrementCounter', { incrementBy: number }>
@@ -71,7 +71,10 @@ describe('handleCommand', () => {
       initialState,
     })
     expect(commandHandlerFunction).toHaveBeenCalledWith({ command: incrementCounterCommand, states: new Map([[streamSubject, mockedAggregatedState]]) })
-    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith([counterIncrementedEvent])
+    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith(
+      [counterIncrementedEvent],
+      { expectedVersions: new Map([[streamSubject, 3]]) },
+    )
     expect(result).toBe(mockedNewState)
   })
 
@@ -104,7 +107,7 @@ describe('handleCommand', () => {
       streamSubjects: [streamSubject],
     }
 
-    mockEventStore.aggregateStream.mockResolvedValue(mockedAggregatedState)
+    mockEventStore.aggregateStream.mockResolvedValue({ state: mockedAggregatedState, streamExists: true, version: 1 })
     mockEventStore.appendOrCreateStream.mockResolvedValue(mockedNewState)
 
     type IncrementCounterCommand = Command<'IncrementCounter', { incrementBy: number }>
@@ -143,7 +146,10 @@ describe('handleCommand', () => {
       initialState,
     })
     expect(commandHandlerFunction).toHaveBeenCalledWith({ command: incrementCounterCommand, states: new Map([[streamSubject, mockedAggregatedState]]) })
-    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith([counterIncrementedEvent])
+    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith(
+      [counterIncrementedEvent],
+      { expectedVersions: new Map([[streamSubject, 1]]) },
+    )
     expect(result).toBe(mockedNewState)
   })
 
@@ -186,7 +192,7 @@ describe('handleCommand', () => {
       streamSubjects: [streamSubject],
     }
 
-    mockEventStore.aggregateStream.mockResolvedValue(mockedAggregatedState)
+    mockEventStore.aggregateStream.mockResolvedValue({ state: mockedAggregatedState, streamExists: true, version: 1 })
     mockEventStore.appendOrCreateStream.mockResolvedValue(mockedNewState)
 
     type IncrementTwiceCommand = Command<'IncrementTwice', { incrementBy: number }>
@@ -231,7 +237,10 @@ describe('handleCommand', () => {
       initialState,
     })
     expect(commandHandlerFunction).toHaveBeenCalledWith({ command: incrementTwiceCommand, states: new Map([[streamSubject, mockedAggregatedState]]) })
-    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith([counterIncrementedEvent1, counterIncrementedEvent2])
+    expect(mockEventStore.appendOrCreateStream).toHaveBeenCalledWith(
+      [counterIncrementedEvent1, counterIncrementedEvent2],
+      { expectedVersions: new Map([[streamSubject, 1]]) },
+    )
     expect(result).toBe(mockedNewState)
   })
 
@@ -309,10 +318,10 @@ describe('handleCommand', () => {
     mockEventStore.aggregateStream
       .mockImplementation(async (streamSubject: string) => {
         if (streamSubject === userStreamSubject) {
-          return mockedUserState
+          return { state: mockedUserState, streamExists: false, version: 0 }
         }
         if (streamSubject === emailListStreamSubject) {
-          return mockedEmailListState
+          return { state: mockedEmailListState, streamExists: true, version: 5 }
         }
         throw new Error(`Unexpected stream subject: ${streamSubject}`)
       })
@@ -415,6 +424,12 @@ describe('handleCommand', () => {
           data: { userId: '123' },
         }),
       ]),
+      {
+        expectedVersions: new Map<string, number>([
+          [userStreamSubject, 0],
+          [emailListStreamSubject, 5],
+        ]),
+      },
     )
 
     expect(result).toBe(mockedNewState)

--- a/packages/eventstore/commandHandling/handleCommand.ts
+++ b/packages/eventstore/commandHandling/handleCommand.ts
@@ -1,3 +1,4 @@
+import type { ExpectedStreamVersion } from '../eventStore/concurrencyError'
 import type { MultiStreamAppendResult } from '../eventStore/eventStoreFactory.types'
 import type { Subject } from '../types/domainEvent.types'
 import type { CommandHandlerOptions, DefaultRecord, InferDomainEventFromCommandHandler, StreamConfig } from './handleCommand.types'
@@ -20,15 +21,19 @@ export async function handleCommand<
 
   /**
    * Aggregate the state of the streams
-   * using the provided evolve functions and initial states
+   * using the provided evolve functions and initial states.
+   * The version seen at read time is remembered per stream so the append
+   * below fails with a ConcurrencyError if a stream changed in between.
    */
   const aggregatedStreamStates: Map<Subject, any> = new Map()
+  const expectedVersions: Map<Subject, ExpectedStreamVersion> = new Map()
   for (const stream of streams) {
-    const aggregatedStreamState = await eventStore.aggregateStream<any, InferDomainEventFromCommandHandler<TCommandHandlerFunction>>(stream.streamSubject, {
+    const { state, version } = await eventStore.aggregateStream<any, InferDomainEventFromCommandHandler<TCommandHandlerFunction>>(stream.streamSubject, {
       evolve: stream.evolve,
       initialState: stream.initialState,
     })
-    aggregatedStreamStates.set(stream.streamSubject, aggregatedStreamState)
+    aggregatedStreamStates.set(stream.streamSubject, state)
+    expectedVersions.set(stream.streamSubject, version)
   }
 
   /**
@@ -40,6 +45,7 @@ export async function handleCommand<
 
   const newState = await eventStore.appendOrCreateStream<InferDomainEventFromCommandHandler<TCommandHandlerFunction>>(
     eventsToAppend,
+    { expectedVersions },
   )
 
   return newState

--- a/packages/eventstore/eventStore/concurrencyError.ts
+++ b/packages/eventstore/eventStore/concurrencyError.ts
@@ -1,0 +1,23 @@
+import type { Subject } from '../types/index'
+
+/**
+ * The stream version a caller expects at append time:
+ * - a number: the stream must have exactly this many events (0 behaves like 'no-stream')
+ * - 'no-stream': the stream must not exist yet, the append creates it
+ * - 'any': no check, append or create unconditionally
+ */
+export type ExpectedStreamVersion = number | 'any' | 'no-stream'
+
+export class ConcurrencyError extends Error {
+  constructor(
+    public readonly streamSubject: Subject,
+    public readonly expectedVersion: ExpectedStreamVersion,
+    public readonly actualVersion?: number,
+  ) {
+    super(
+      `Concurrency conflict on stream "${streamSubject}": expected version ${expectedVersion}, ${
+        actualVersion === undefined ? 'but the stream state changed concurrently' : `actual version is ${actualVersion}`}`,
+    )
+    this.name = 'ConcurrencyError'
+  }
+}

--- a/packages/eventstore/eventStore/eventStoreFactory.test.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { createDomainEvent, createEventStream } from '../utils/utilsEventStore'
 import { createProjectionDefinition } from '../utils/utilsProjections'
 import { createSubject, getStreamSubjectFromSubject } from '../utils/utilsSubject'
+import { ConcurrencyError } from './concurrencyError'
 import { createEventStore } from './eventStoreFactory'
 
 describe('mongoClientWrapper Integration Tests', () => {
@@ -55,6 +56,7 @@ describe('mongoClientWrapper Integration Tests', () => {
       expect(result).toEqual({
         events: [],
         streamExists: false,
+        version: 0,
       })
     })
 
@@ -388,6 +390,137 @@ describe('mongoClientWrapper Integration Tests', () => {
     })
   })
 
+  describe('optimistic concurrency control', () => {
+    it('should set and increment the stream version on append', async () => {
+      const first = await eventStore.appendOrCreateStream([testEvent])
+      expect(first.streams[0]!.version).toBe(1)
+
+      const secondEvent = createDomainEvent({
+        type: 'user.updated',
+        subject: subjectExisting,
+        data: { name: 'Alice Updated' },
+      })
+      const second = await eventStore.appendOrCreateStream([secondEvent])
+      expect(second.streams[0]!.version).toBe(2)
+    })
+
+    it('should append when the expected version matches', async () => {
+      await eventStore.appendOrCreateStream([testEvent])
+
+      const secondEvent = createDomainEvent({
+        type: 'user.updated',
+        subject: subjectExisting,
+        data: { name: 'Alice Updated' },
+      })
+      const result = await eventStore.appendOrCreateStream([secondEvent], {
+        expectedVersions: new Map([[streamSubject, 1]]),
+      })
+
+      expect(result.streams[0]!.version).toBe(2)
+      expect(result.streams[0]!.events.length).toBe(2)
+    })
+
+    it('should throw ConcurrencyError and write nothing when the expected version does not match', async () => {
+      await eventStore.appendOrCreateStream([testEvent])
+
+      const secondEvent = createDomainEvent({
+        type: 'user.updated',
+        subject: subjectExisting,
+        data: { name: 'Alice Updated' },
+      })
+
+      const append = eventStore.appendOrCreateStream([secondEvent], {
+        expectedVersions: new Map([[streamSubject, 5]]),
+      })
+
+      await expect(append).rejects.toThrowError(ConcurrencyError)
+      await expect(eventStore.appendOrCreateStream([secondEvent], {
+        expectedVersions: new Map([[streamSubject, 5]]),
+      })).rejects.toMatchObject({
+        streamSubject,
+        expectedVersion: 5,
+        actualVersion: 1,
+      })
+
+      const { events } = await eventStore.getEventStreamBySubject(streamSubject)
+      expect(events.length).toBe(1)
+    })
+
+    it('should throw ConcurrencyError for no-stream when the stream already exists', async () => {
+      // Fresh instance: the shared store's ensure cache believes the unique
+      // index still exists, but afterEach dropped the collection with it.
+      const freshStore = createEventStore({ connectionString })
+      await freshStore.getInstanceMongoClientWrapper().waitForConnection()
+
+      await freshStore.appendOrCreateStream([testEvent])
+
+      const append = freshStore.appendOrCreateStream([testEvent], {
+        expectedVersions: new Map([[streamSubject, 'no-stream' as const]]),
+      })
+
+      await expect(append).rejects.toThrowError(ConcurrencyError)
+    })
+
+    it('should create the stream when no-stream is expected and it does not exist', async () => {
+      const result = await eventStore.appendOrCreateStream([testEvent], {
+        expectedVersions: new Map([[streamSubject, 'no-stream' as const]]),
+      })
+
+      expect(result.streams[0]!.version).toBe(1)
+      const { streamExists } = await eventStore.getEventStreamBySubject(streamSubject)
+      expect(streamExists).toBe(true)
+    })
+
+    it('should roll back all streams when one expected version does not match', async () => {
+      const otherSubject = createSubject('user/456/created')
+      const otherStreamSubject = getStreamSubjectFromSubject(otherSubject)
+      const otherEvent = createDomainEvent({
+        type: 'user.created',
+        subject: otherSubject,
+        data: { name: 'Bob Example' },
+      })
+
+      await eventStore.appendOrCreateStream([testEvent])
+
+      const append = eventStore.appendOrCreateStream([testEvent, otherEvent], {
+        expectedVersions: new Map<typeof streamSubject, number>([
+          [streamSubject, 1],
+          [otherStreamSubject, 7],
+        ]),
+      })
+
+      await expect(append).rejects.toThrowError(ConcurrencyError)
+
+      const existing = await eventStore.getEventStreamBySubject(streamSubject)
+      expect(existing.events.length).toBe(1)
+      const other = await eventStore.getEventStreamBySubject(otherStreamSubject)
+      expect(other.streamExists).toBe(false)
+    })
+
+    it('should backfill the version field on documents written before versioning', async () => {
+      const collection = eventStore.getCollectionBySubject(streamSubject)
+      const legacyStream = createEventStream([testEvent])
+      delete (legacyStream as Partial<typeof legacyStream>).version
+      await collection.insertOne(legacyStream, { ignoreUndefined: true })
+
+      const legacyAwareStore = createEventStore({ connectionString })
+      await legacyAwareStore.getInstanceMongoClientWrapper().waitForConnection()
+
+      const read = await legacyAwareStore.getEventStreamBySubject(streamSubject)
+      expect(read.version).toBe(1)
+
+      const secondEvent = createDomainEvent({
+        type: 'user.updated',
+        subject: subjectExisting,
+        data: { name: 'Alice Updated' },
+      })
+      const result = await legacyAwareStore.appendOrCreateStream([secondEvent], {
+        expectedVersions: new Map([[streamSubject, 1]]),
+      })
+      expect(result.streams[0]!.version).toBe(2)
+    })
+  })
+
   describe('aggregateStream', () => {
     const firstTestEvent = createDomainEvent({
       type: 'user.created',
@@ -420,7 +553,11 @@ describe('mongoClientWrapper Integration Tests', () => {
         initialState,
       })
 
-      expect(result).toEqual({ count: 0, events: [] })
+      expect(result).toEqual({
+        state: { count: 0, events: [] },
+        streamExists: false,
+        version: 0,
+      })
     })
 
     it('should aggregate events from existing stream', async () => {
@@ -434,8 +571,12 @@ describe('mongoClientWrapper Integration Tests', () => {
       })
 
       expect(result).toEqual({
-        count: 1,
-        events: [firstTestEvent.type],
+        state: {
+          count: 1,
+          events: [firstTestEvent.type],
+        },
+        streamExists: true,
+        version: 1,
       })
     })
 
@@ -456,8 +597,12 @@ describe('mongoClientWrapper Integration Tests', () => {
       })
 
       expect(result).toEqual({
-        count: 100, // 1 + 99 from the two events
-        events: [firstTestEvent.type, secondTestEvent.type],
+        state: {
+          count: 100, // 1 + 99 from the two events
+          events: [firstTestEvent.type, secondTestEvent.type],
+        },
+        streamExists: true,
+        version: 2,
       })
     })
   })

--- a/packages/eventstore/eventStore/eventStoreFactory.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.ts
@@ -192,6 +192,26 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
   const mongoClient = new MongoClientWrapper(mongoClientOptions)
   const projections = configuredProjections || ([] as unknown as TProjections)
 
+  // Replica set elections interrupt the majority write concern of otherwise
+  // successful writes (e.g. InterruptedDueToReplStateChange). The ensure
+  // operations are idempotent, so retrying on stepdown-related codes is safe.
+  const TRANSIENT_WRITE_CODES = new Set([11602, 91, 189, 10107])
+  async function retryTransient<T>(op: () => Promise<T>): Promise<T> {
+    let lastError: unknown
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await op()
+      }
+      catch (error) {
+        if (!(error instanceof MongoServerError) || !TRANSIENT_WRITE_CODES.has(Number(error.code))) {
+          throw error
+        }
+        lastError = error
+      }
+    }
+    throw lastError
+  }
+
   // Index creation is not allowed inside a transaction, so the unique index on
   // streamSubject is ensured (once per collection) before appends start. The
   // same step backfills the version field on documents written before
@@ -203,11 +223,11 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
     let ensured = ensuredCollections.get(key)
     if (!ensured) {
       ensured = Promise.all([
-        collection.createIndex({ streamSubject: 1 }, { unique: true }),
-        collection.updateMany(
+        retryTransient(() => collection.createIndex({ streamSubject: 1 }, { unique: true })),
+        retryTransient(() => collection.updateMany(
           { version: { $exists: false } },
           [{ $set: { version: { $size: '$events' } } }],
-        ),
+        )),
       ])
       ensured.catch(() => ensuredCollections.delete(key))
       ensuredCollections.set(key, ensured)

--- a/packages/eventstore/eventStore/eventStoreFactory.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.ts
@@ -1,11 +1,14 @@
-import type { ClientSession, Collection, PushOperator, UpdateFilter } from 'mongodb'
+import type { ClientSession, Collection, Filter, OptionalUnlessRequiredId, PushOperator, UpdateFilter } from 'mongodb'
 import type { AnyDomainEvent, Subject } from '../types/index'
 import type { ProjectionDefinition } from '../utils/utilsProjections.types'
-import type { EventStoreOptions, EventStream, MultiStreamAppendResult, ReadStreamResult } from './eventStoreFactory.types'
+import type { ExpectedStreamVersion } from './concurrencyError'
+import type { AggregateStreamResult, AppendStreamOptions, EventStoreOptions, EventStream, MultiStreamAppendResult, ReadStreamResult } from './eventStoreFactory.types'
 import { randomUUID } from 'node:crypto'
+import { MongoServerError } from 'mongodb'
 import { MongoClientWrapper } from '../mongoClient/mongoClientWrapper'
 import { groupEventsByStreamSubject } from '../utils/utilsEventStore'
 import { getCollectionNameFromSubject, getStreamSubjectFromSubject } from '../utils/utilsSubject'
+import { ConcurrencyError } from './concurrencyError'
 
 export interface EventStoreInstance<
   TProjections extends readonly ProjectionDefinition<any, any, any>[] | undefined = undefined,
@@ -29,9 +32,10 @@ export interface EventStoreInstance<
       evolve: (state: State, event: TDomainEvent) => State
       initialState: () => State
     },
-  ) => Promise<State>
+  ) => Promise<AggregateStreamResult<State>>
   appendOrCreateStream: <TDomainEvent extends AnyDomainEvent>(
     events: Array<TDomainEvent>,
+    options?: AppendStreamOptions,
   ) => Promise<MultiStreamAppendResult<TDomainEvent, TProjections>>
 }
 
@@ -46,36 +50,90 @@ async function processStreamInTransaction<
   events: Array<TDomainEvent>,
   collection: Collection<EventStream<TDomainEvent, TProjections>>,
   projections: TProjections,
+  expectedVersion: ExpectedStreamVersion,
   session?: ClientSession,
 ): Promise<EventStream<TDomainEvent, TProjections>> {
   const now = new Date()
 
-  const updates: UpdateFilter<EventStream<TDomainEvent, TProjections>> = {
-    $setOnInsert: {
-      'streamId': randomUUID(),
-      'metadata.createdAt': now,
-      streamSubject,
-    },
-    $set: {
-      'metadata.updatedAt': now,
-    },
-    $push: {
-      events: { $each: events },
-    } as PushOperator<EventStream<TDomainEvent, TProjections>>,
-  }
+  let result: EventStream<TDomainEvent, TProjections> | null
 
-  let result = await collection.findOneAndUpdate(
-    { streamSubject },
-    updates,
-    {
-      useBigInt64: true,
-      upsert: true,
-      ignoreUndefined: true,
-      returnDocument: 'after',
-      projection: { _id: 0 },
-      ...(session && { session }),
-    },
-  )
+  if (expectedVersion === 'no-stream' || expectedVersion === 0) {
+    const newStream = {
+      streamId: randomUUID(),
+      streamSubject,
+      events,
+      version: events.length,
+      metadata: {
+        createdAt: now,
+        updatedAt: now,
+      },
+    } as OptionalUnlessRequiredId<EventStream<TDomainEvent, TProjections>>
+
+    try {
+      await collection.insertOne(newStream, {
+        ignoreUndefined: true,
+        ...(session && { session }),
+      })
+    }
+    catch (error) {
+      // The unique index on streamSubject rejects a concurrent create. The
+      // actual version cannot be read here: the failed write already aborted
+      // the transaction.
+      if (error instanceof MongoServerError && error.code === 11000) {
+        throw new ConcurrencyError(streamSubject, expectedVersion)
+      }
+      throw error
+    }
+
+    delete (newStream as { _id?: unknown })._id
+    result = newStream as EventStream<TDomainEvent, TProjections>
+  }
+  else {
+    const versionFilter: Filter<EventStream<TDomainEvent, TProjections>>
+      = typeof expectedVersion === 'number'
+        ? ({ streamSubject, version: expectedVersion } as Filter<EventStream<TDomainEvent, TProjections>>)
+        : ({ streamSubject } as Filter<EventStream<TDomainEvent, TProjections>>)
+
+    const updates: UpdateFilter<EventStream<TDomainEvent, TProjections>> = {
+      $setOnInsert: {
+        'streamId': randomUUID(),
+        'metadata.createdAt': now,
+        streamSubject,
+      },
+      $set: {
+        'metadata.updatedAt': now,
+      },
+      $inc: {
+        version: events.length,
+      } as NonNullable<UpdateFilter<EventStream<TDomainEvent, TProjections>>['$inc']>,
+      $push: {
+        events: { $each: events },
+      } as PushOperator<EventStream<TDomainEvent, TProjections>>,
+    }
+
+    result = await collection.findOneAndUpdate(
+      versionFilter,
+      updates,
+      {
+        useBigInt64: true,
+        // With an exact expected version an upsert would create a second
+        // document on a version mismatch instead of failing the check.
+        upsert: expectedVersion === 'any',
+        ignoreUndefined: true,
+        returnDocument: 'after',
+        projection: { _id: 0 },
+        ...(session && { session }),
+      },
+    )
+
+    if (!result && typeof expectedVersion === 'number') {
+      const actual = await collection.findOne(
+        { streamSubject } as Filter<EventStream<TDomainEvent, TProjections>>,
+        { projection: { version: 1, events: 1 }, ...(session && { session }) },
+      )
+      throw new ConcurrencyError(streamSubject, expectedVersion, actual ? actual.version ?? actual.events.length : undefined)
+    }
+  }
 
   if (projections && projections.length > 0) {
     const eventTypes = events.map(event => event.type)
@@ -135,15 +193,24 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
   const projections = configuredProjections || ([] as unknown as TProjections)
 
   // Index creation is not allowed inside a transaction, so the unique index on
-  // streamSubject is ensured (once per collection) before appends start.
-  const ensuredIndexes = new Map<string, Promise<string>>()
-  function ensureStreamSubjectIndex(collection: Collection<any>): Promise<string> {
+  // streamSubject is ensured (once per collection) before appends start. The
+  // same step backfills the version field on documents written before
+  // versioning existed — the $inc on append would otherwise start at 0 and the
+  // exact-version filter would never match them.
+  const ensuredCollections = new Map<string, Promise<unknown>>()
+  function ensureCollectionReady(collection: Collection<any>): Promise<unknown> {
     const key = collection.collectionName
-    let ensured = ensuredIndexes.get(key)
+    let ensured = ensuredCollections.get(key)
     if (!ensured) {
-      ensured = collection.createIndex({ streamSubject: 1 }, { unique: true })
-      ensured.catch(() => ensuredIndexes.delete(key))
-      ensuredIndexes.set(key, ensured)
+      ensured = Promise.all([
+        collection.createIndex({ streamSubject: 1 }, { unique: true }),
+        collection.updateMany(
+          { version: { $exists: false } },
+          [{ $set: { version: { $size: '$events' } } }],
+        ),
+      ])
+      ensured.catch(() => ensuredCollections.delete(key))
+      ensuredCollections.set(key, ensured)
     }
     return ensured
   }
@@ -185,11 +252,15 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
         return {
           events: [],
           streamExists: false,
+          version: 0,
         }
       }
       return {
         events: stream.events,
         streamExists: true,
+        // Documents written before versioning existed carry no version field
+        // until the first append backfills the collection.
+        version: stream.version ?? stream.events.length,
       }
     },
 
@@ -202,61 +273,25 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
         evolve: (state: State, event: TDomainEvent) => State
         initialState: () => State
       },
-    ): Promise<State> {
+    ): Promise<AggregateStreamResult<State>> {
       const { evolve, initialState } = options
-      const { events } = await this.getEventStreamBySubject<TDomainEvent>(streamSubject)
-      if (!events) {
-        return initialState()
-      }
+      const { events, streamExists, version } = await this.getEventStreamBySubject<TDomainEvent>(streamSubject)
       const state = events.reduce((state, event) => evolve(state, event), initialState())
-      return state
+      return { state, streamExists, version }
     },
 
     async appendOrCreateStream<TDomainEvent extends AnyDomainEvent>(
       events: Array<TDomainEvent>,
+      options?: AppendStreamOptions,
     ): Promise<MultiStreamAppendResult<TDomainEvent, TProjections>> {
       if (!events || events.length === 0) {
         throw new Error('Cannot process an empty array of events')
       }
 
-      // Group events by stream subject
       const eventGroups = groupEventsByStreamSubject(events)
 
-      // If all events belong to the same stream, we can optimize by avoiding transaction overhead
-      if (eventGroups.size === 1) {
-        const firstEntry = eventGroups.entries().next().value as [Subject, Array<TDomainEvent>]
-        const [streamSubject, streamEvents] = firstEntry
-        const collection = this.getCollectionBySubject<TDomainEvent>(streamSubject)
-        await ensureStreamSubjectIndex(collection)
-
-        const client = mongoClient.getClient()
-        const session = client.startSession()
-
-        try {
-          const result = await session.withTransaction(async () => {
-            return await processStreamInTransaction(
-              streamSubject,
-              streamEvents,
-              collection,
-              projections,
-              session,
-            )
-          })
-
-          return {
-            streams: [result],
-            totalEventsAppended: events.length,
-            streamSubjects: [streamSubject],
-          }
-        }
-        finally {
-          await session.endSession()
-        }
-      }
-
-      // Handle multiple streams with MongoDB transaction
       for (const streamSubject of eventGroups.keys()) {
-        await ensureStreamSubjectIndex(this.getCollectionBySubject(streamSubject))
+        await ensureCollectionReady(this.getCollectionBySubject(streamSubject))
       }
 
       const client = mongoClient.getClient()
@@ -273,6 +308,7 @@ export function createEventStore<TProjections extends readonly ProjectionDefinit
               streamEvents,
               collection,
               projections,
+              options?.expectedVersions?.get(streamSubject) ?? 'any',
               session,
             )
             streamResults.push(result)

--- a/packages/eventstore/eventStore/eventStoreFactory.types.ts
+++ b/packages/eventstore/eventStore/eventStoreFactory.types.ts
@@ -2,6 +2,7 @@ import type { Document, Filter } from 'mongodb'
 import type { MongoClientWrapperOptions } from '../mongoClient/mongoClientWrapper.types'
 import type { AnyDomainEvent, Subject } from '../types/index'
 import type { ProjectionDefinition, ProjectionNames, ProjectionStates, ProjectionStatesWith } from '../utils/utilsProjections.types'
+import type { ExpectedStreamVersion } from './concurrencyError'
 
 export interface EventStoreOptions<TProjections extends readonly ProjectionDefinition<any, any, any>[] | undefined = undefined> extends MongoClientWrapperOptions {
   projections?: TProjections
@@ -14,6 +15,8 @@ export interface EventStream<
   streamId: string
   streamSubject: Subject
   events: Array<TDomainEvent>
+  /** Number of events in the stream, used for optimistic concurrency checks */
+  version: number
   metadata: {
     createdAt: Date
     updatedAt: Date
@@ -40,6 +43,24 @@ export interface ReadStreamResult<
 > {
   events: Array<TDomainEvent>
   streamExists: boolean
+  /** Current stream version (0 if the stream does not exist) */
+  version: number
+}
+
+export interface AggregateStreamResult<State> {
+  state: State
+  streamExists: boolean
+  /** Stream version at read time; pass as expectedVersion when appending */
+  version: number
+}
+
+export interface AppendStreamOptions {
+  /**
+   * Expected version per stream subject. Streams not listed are appended
+   * unconditionally ('any'). On a mismatch the whole append (all streams in
+   * the call) is rolled back with a ConcurrencyError.
+   */
+  expectedVersions?: ReadonlyMap<Subject, ExpectedStreamVersion>
 }
 
 export interface ProjectionQuery<TProjectionName extends string> {

--- a/packages/eventstore/index.ts
+++ b/packages/eventstore/index.ts
@@ -1,5 +1,6 @@
 export * from './commandHandling/handleCommand'
 export * from './commandHandling/utilsCommand'
+export * from './eventStore/concurrencyError'
 export * from './eventStore/eventStoreFactory'
 export * from './eventStore/eventStoreFactory.types'
 export * from './mongoClient/mongoClientWrapper.types'

--- a/packages/eventstore/utils/utilsEventStore.ts
+++ b/packages/eventstore/utils/utilsEventStore.ts
@@ -91,6 +91,7 @@ export function createEventStream<TDomainEvent extends AnyDomainEvent>(
     streamId: randomUUID(),
     streamSubject,
     events,
+    version: events.length,
     metadata: {
       createdAt: new Date(),
       updatedAt: new Date(),


### PR DESCRIPTION
Implements the OCC design discussed in review, without backwards compatibility:

- `EventStream` documents carry `version` (number of events); appends `$inc` it.
- `appendOrCreateStream(events, { expectedVersions })` accepts per-stream expectations: exact number (`0` ≙ must not exist), `'no-stream'` (insert path, guarded by the unique `streamSubject` index) or `'any'` (default, unconditional upsert). A mismatch throws the new exported `ConcurrencyError` (with `streamSubject`, `expectedVersion`, `actualVersion`) and rolls back the entire multi-stream append.
- `aggregateStream` returns `{ state, version, streamExists }`; `getEventStreamBySubject` returns `version` (**breaking**).
- `handleCommand` passes the versions observed while aggregating as `expectedVersions` — the read-decide-append race is closed without application code changes.
- Legacy documents without `version` are backfilled (`$size` of `events`) once per collection in the same ensure step that creates the unique index.
- The redundant single-stream branch in `appendOrCreateStream` is removed (its "avoid transaction overhead" comment was never true — it started a transaction anyway).

Tests: 7 new integration tests (version increment, match/mismatch, `no-stream` both ways, multi-stream rollback, legacy backfill); existing `aggregateStream`/`handleCommand` tests updated to the new signatures. 74/74 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)